### PR TITLE
Enhance UI and features: repo selector, search, sorting, pagination, caching and theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,23 @@
             --accent-hover: #1f6feb;
             --border: #30363d;
             --btn-bg: #21262d;
+            --danger: #ff7b72;
+            --success: #3fb950;
+            --badge-bg: #1f2937;
+        }
+
+        body[data-theme="light"] {
+            --bg-color: #f6f8fa;
+            --card-bg: #ffffff;
+            --text-main: #1f2328;
+            --text-muted: #57606a;
+            --accent: #0969da;
+            --accent-hover: #0550ae;
+            --border: #d0d7de;
+            --btn-bg: #f6f8fa;
+            --danger: #cf222e;
+            --success: #1a7f37;
+            --badge-bg: #f3f4f6;
         }
 
         body {
@@ -27,36 +44,110 @@
             flex-direction: column;
             align-items: center;
             min-height: 100vh;
+            transition: background-color 0.2s, color 0.2s;
         }
 
         h1 {
-            color: #fff;
-            margin-bottom: 30px;
+            color: var(--text-main);
+            margin-bottom: 24px;
             font-size: 2.5rem;
             text-align: center;
             border-bottom: 2px solid var(--border);
             padding-bottom: 10px;
             width: 100%;
-            max-width: 800px;
+            max-width: 960px;
         }
 
-        /* Container Principal */
-        #releases {
+        #app {
             width: 100%;
-            max-width: 800px;
+            max-width: 960px;
             display: flex;
             flex-direction: column;
             gap: 20px;
         }
 
-        /* Cartão da Release */
+        .toolbar {
+            display: grid;
+            grid-template-columns: 1.2fr auto auto auto;
+            gap: 12px;
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 14px;
+        }
+
+        .repo-bar {
+            display: grid;
+            grid-template-columns: 1fr 1fr auto;
+            gap: 10px;
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 14px;
+        }
+
+        .toolbar-input,
+        .toolbar-select,
+        .toolbar-button {
+            background: var(--btn-bg);
+            border: 1px solid var(--border);
+            color: var(--text-main);
+            border-radius: 6px;
+            padding: 10px 12px;
+            font-size: 0.95rem;
+        }
+
+        .toolbar-button {
+            cursor: pointer;
+            font-weight: 600;
+        }
+
+        .toolbar-button:hover {
+            border-color: var(--accent);
+        }
+
+        .toolbar-label {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 0.9rem;
+            color: var(--text-muted);
+            user-select: none;
+        }
+
+        .toolbar-label input {
+            accent-color: var(--accent);
+        }
+
+        .summary {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+
+        .badge {
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            padding: 8px 12px;
+            font-size: 0.85rem;
+            color: var(--text-muted);
+            background-color: var(--badge-bg);
+        }
+
+        #releases {
+            width: 100%;
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+
         .release-card {
             background-color: var(--card-bg);
             border: 1px solid var(--border);
             border-radius: 8px;
             padding: 20px;
-            box-shadow: 0 4px 6px rgba(0,0,0,0.3);
-            transition: transform 0.2s;
+            box-shadow: 0 4px 6px rgba(0,0,0,0.12);
+            transition: border-color 0.2s;
         }
 
         .release-card:hover {
@@ -78,13 +169,33 @@
             color: var(--accent);
         }
 
+        .release-title a {
+            color: inherit;
+            text-decoration: none;
+        }
+
+        .release-title a:hover {
+            text-decoration: underline;
+        }
+
         .release-tag {
             background-color: var(--border);
             padding: 4px 8px;
             border-radius: 4px;
             font-size: 0.85rem;
-            color: #fff;
+            color: var(--text-main);
             font-weight: bold;
+        }
+
+        .release-tag.prerelease {
+            background: #7d4e00;
+            color: #ffd8a8;
+        }
+
+        body[data-theme="light"] .release-tag.prerelease {
+            background: #fff1cc;
+            color: #9a6700;
+            border: 1px solid #d4a72c;
         }
 
         .release-date {
@@ -97,24 +208,30 @@
         .release-body {
             color: var(--text-main);
             margin-bottom: 20px;
-            white-space: pre-wrap; /* Mantém quebras de linha */
+            white-space: pre-wrap;
             font-size: 0.95rem;
             line-height: 1.5;
-            background: rgba(0,0,0,0.2);
+            background: rgba(0,0,0,0.07);
             padding: 10px;
             border-radius: 6px;
         }
 
-        /* Lista de Assets (Downloads) */
         .assets-list {
             display: flex;
             flex-direction: column;
             gap: 10px;
         }
 
+        .asset-row {
+            display: flex;
+            gap: 8px;
+            align-items: stretch;
+        }
+
         .download-btn {
             display: flex;
             align-items: center;
+            gap: 10px;
             background-color: var(--btn-bg);
             color: var(--accent);
             text-decoration: none;
@@ -123,17 +240,29 @@
             border: 1px solid var(--border);
             transition: all 0.2s;
             font-weight: 500;
+            flex: 1;
         }
 
         .download-btn:hover {
             background-color: var(--border);
-            color: #fff;
-            transform: translateX(5px);
+            color: var(--text-main);
+            transform: translateX(3px);
         }
 
-        .download-btn i {
-            margin-right: 10px;
-            font-size: 1.2rem;
+        .copy-btn {
+            border: 1px solid var(--border);
+            background: var(--btn-bg);
+            color: var(--text-muted);
+            border-radius: 6px;
+            padding: 0 12px;
+            font-size: 0.9rem;
+            cursor: pointer;
+            white-space: nowrap;
+        }
+
+        .copy-btn:hover {
+            color: var(--accent);
+            border-color: var(--accent);
         }
 
         .file-info {
@@ -150,7 +279,6 @@
             color: var(--text-muted);
         }
 
-        /* Loader */
         .loader {
             border: 4px solid var(--card-bg);
             border-top: 4px solid var(--accent);
@@ -161,34 +289,137 @@
             margin: 50px auto;
         }
 
+        .pagination {
+            display: flex;
+            gap: 12px;
+            align-items: center;
+            justify-content: center;
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 12px;
+        }
+
+        .pagination button {
+            border: 1px solid var(--border);
+            background: var(--btn-bg);
+            color: var(--text-main);
+            border-radius: 6px;
+            padding: 8px 12px;
+            cursor: pointer;
+        }
+
+        .pagination button:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+        }
+
+        .pagination span {
+            color: var(--text-muted);
+            font-size: 0.9rem;
+        }
+
         @keyframes spin {
             0% { transform: rotate(0deg); }
             100% { transform: rotate(360deg); }
         }
 
         .error-msg {
-            color: #ff7b72;
+            color: var(--danger);
             text-align: center;
             padding: 20px;
-            background: rgba(255, 0, 0, 0.1);
+            background: rgba(255, 0, 0, 0.08);
             border-radius: 8px;
+        }
+
+        .empty {
+            text-align: center;
+            color: var(--text-muted);
+            background: var(--card-bg);
+            border: 1px dashed var(--border);
+            border-radius: 8px;
+            padding: 24px;
+        }
+
+        @media (max-width: 800px) {
+            h1 {
+                font-size: 1.9rem;
+            }
+
+            .toolbar,
+            .repo-bar {
+                grid-template-columns: 1fr;
+            }
+
+            .asset-row {
+                flex-direction: column;
+            }
+
+            .copy-btn {
+                padding: 10px 12px;
+            }
         }
     </style>
 </head>
 <body>
     <h1><i class="fab fa-github"></i> Auto Dowm</h1>
-    
-    <div id="releases">
-        <div class="loader" id="loader"></div>
-    </div>
+
+    <main id="app">
+        <section class="repo-bar" aria-label="Configuração de repositório">
+            <input id="ownerInput" class="toolbar-input" type="text" placeholder="Owner (ex.: phoenixsrd)" aria-label="Owner do repositório">
+            <input id="repoInput" class="toolbar-input" type="text" placeholder="Repo (ex.: autodowm)" aria-label="Nome do repositório">
+            <button id="applyRepoBtn" class="toolbar-button" type="button"><i class="fas fa-rotate"></i> Carregar</button>
+        </section>
+
+        <section class="toolbar" aria-label="Filtros de release">
+            <input id="searchInput" class="toolbar-input" type="search" placeholder="Buscar por nome, tag ou descrição..." aria-label="Buscar releases">
+            <select id="sortSelect" class="toolbar-select" aria-label="Ordenar releases">
+                <option value="newest">Mais recentes</option>
+                <option value="oldest">Mais antigas</option>
+                <option value="assets">Mais arquivos</option>
+                <option value="downloads">Mais downloads</option>
+            </select>
+            <label class="toolbar-label" for="showPrerelease">
+                <input id="showPrerelease" type="checkbox">
+                Incluir pré-releases
+            </label>
+            <button id="themeToggle" class="toolbar-button" type="button" aria-label="Alternar tema"><i class="fas fa-circle-half-stroke"></i> Tema</button>
+        </section>
+
+        <section id="summary" class="summary" aria-live="polite"></section>
+
+        <section id="releases" aria-live="polite">
+            <div class="loader" id="loader"></div>
+        </section>
+
+        <section id="pagination" class="pagination" aria-label="Paginação"></section>
+    </main>
 
     <script>
-        const repoOwner = 'phoenixsrd';
-        const repoName = 'autodowm';
-        
-        const apiURL = `https://api.github.com/repos/${repoOwner}/${repoName}/releases`;
+        const DEFAULT_OWNER = 'phoenixsrd';
+        const DEFAULT_REPO = 'autodowm';
+        const PAGE_SIZE = 6;
+        const CACHE_TTL_MS = 5 * 60 * 1000;
+        const API_PAGE_SIZE = 100;
+
         const releasesContainer = document.getElementById('releases');
+        const summaryContainer = document.getElementById('summary');
+        const paginationContainer = document.getElementById('pagination');
         const loader = document.getElementById('loader');
+        const searchInput = document.getElementById('searchInput');
+        const sortSelect = document.getElementById('sortSelect');
+        const showPrerelease = document.getElementById('showPrerelease');
+        const ownerInput = document.getElementById('ownerInput');
+        const repoInput = document.getElementById('repoInput');
+        const applyRepoBtn = document.getElementById('applyRepoBtn');
+        const themeToggle = document.getElementById('themeToggle');
+
+        const state = {
+            owner: DEFAULT_OWNER,
+            repo: DEFAULT_REPO,
+            allReleases: [],
+            currentPage: 1
+        };
 
         const formatDate = (dateString) => {
             const options = { year: 'numeric', month: 'short', day: 'numeric' };
@@ -204,72 +435,440 @@
             return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
         };
 
-        fetch(apiURL)
-            .then(response => {
-                if (!response.ok) throw new Error(`Erro HTTP: ${response.status}`);
-                return response.json();
-            })
-            .then(data => {
-                loader.style.display = 'none';
+        const totalDownloads = (release) => release.assets.reduce((acc, asset) => acc + asset.download_count, 0);
 
-                if (data.length === 0) {
-                    releasesContainer.innerHTML = '<p style="text-align:center">Nenhuma release encontrada.</p>';
-                    return;
+        const buildApiURL = (page = 1) => `https://api.github.com/repos/${encodeURIComponent(state.owner)}/${encodeURIComponent(state.repo)}/releases?per_page=${API_PAGE_SIZE}&page=${page}`;
+
+        const getCacheKey = () => `autodowm-releases:${state.owner}/${state.repo}`;
+
+        const getThemeStorageKey = () => 'autodowm-theme';
+
+        const storageGet = (key) => {
+            try {
+                return localStorage.getItem(key);
+            } catch (error) {
+                console.warn('localStorage indisponível para leitura:', error);
+                return null;
+            }
+        };
+
+        const storageSet = (key, value) => {
+            try {
+                localStorage.setItem(key, value);
+            } catch (error) {
+                console.warn('localStorage indisponível para escrita:', error);
+            }
+        };
+
+        const storageRemove = (key) => {
+            try {
+                localStorage.removeItem(key);
+            } catch (error) {
+                console.warn('localStorage indisponível para remoção:', error);
+            }
+        };
+
+        const saveTheme = (theme) => storageSet(getThemeStorageKey(), theme);
+
+        const applyTheme = (theme) => {
+            document.body.dataset.theme = theme;
+            saveTheme(theme);
+        };
+
+        const initTheme = () => {
+            const saved = storageGet(getThemeStorageKey());
+            const preferredDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            applyTheme(saved || (preferredDark ? 'dark' : 'light'));
+        };
+
+        const toggleTheme = () => {
+            const current = document.body.dataset.theme === 'light' ? 'light' : 'dark';
+            applyTheme(current === 'dark' ? 'light' : 'dark');
+        };
+
+        const getCachedReleases = () => {
+            const raw = storageGet(getCacheKey());
+            if (!raw) {
+                return null;
+            }
+
+            try {
+                const parsed = JSON.parse(raw);
+                if (!parsed.timestamp || !Array.isArray(parsed.data)) {
+                    return null;
                 }
-                
-                data.forEach(release => {
-                    const card = document.createElement('div');
-                    card.className = 'release-card';
 
-                    const headerHtml = `
-                        <div class="release-header">
-                            <h2 class="release-title">${release.name || release.tag_name}</h2>
-                            <span class="release-tag"><i class="fas fa-tag"></i> ${release.tag_name}</span>
-                            <div class="release-date">Publicado em: ${formatDate(release.published_at)}</div>
-                        </div>
-                    `;
+                if (Date.now() - parsed.timestamp > CACHE_TTL_MS) {
+                    storageRemove(getCacheKey());
+                    return null;
+                }
 
-                    const bodyText = release.body ? release.body : "Sem notas de atualização.";
-                    const bodyHtml = `<div class="release-body">${bodyText}</div>`;
+                return parsed.data;
+            } catch (error) {
+                console.warn('Cache inválido ignorado:', error);
+                return null;
+            }
+        };
 
-                    const assetsContainer = document.createElement('div');
-                    assetsContainer.className = 'assets-list';
+        const setCachedReleases = (data) => {
+            const payload = {
+                timestamp: Date.now(),
+                data
+            };
+            storageSet(getCacheKey(), JSON.stringify(payload));
+        };
 
-                    if (release.assets.length > 0) {
-                        release.assets.forEach(asset => {
-                            const btn = document.createElement('a');
-                            btn.className = 'download-btn';
-                            btn.href = asset.browser_download_url;
-                            btn.innerHTML = `
-                                <i class="fas fa-download"></i>
-                                <div class="file-info">
-                                    <span class="file-name">${asset.name}</span>
-                                    <span class="file-size">${formatBytes(asset.size)} • ${asset.download_count} downloads</span>
-                                </div>
-                            `;
-                            assetsContainer.appendChild(btn);
-                        });
-                    } else {
-                        assetsContainer.innerHTML = '<p style="font-size:0.9rem; color:#8b949e;">Nenhum arquivo anexado (apenas código fonte).</p>';
-                    }
+        const fetchAllReleases = async () => {
+            const all = [];
+            let page = 1;
 
-                    card.innerHTML = headerHtml + bodyHtml;
-                    card.appendChild(assetsContainer);
-                    releasesContainer.appendChild(card);
-                });
-            })
-            .catch(error => {
-                loader.style.display = 'none';
-                console.error('Erro:', error);
-                releasesContainer.innerHTML = `
-                    <div class="error-msg">
-                        <h3><i class="fas fa-exclamation-triangle"></i> Ops!</h3>
-                        <p>Não foi possível carregar as releases.</p>
-                        <p>Verifique se o repositório é público ou tente novamente mais tarde.</p>
-                        <small>Erro: ${error.message}</small>
-                    </div>
-                `;
+            while (true) {
+                const response = await fetch(buildApiURL(page));
+                if (!response.ok) {
+                    throw new Error(`Erro HTTP: ${response.status}`);
+                }
+
+                const pageData = await response.json();
+                if (!Array.isArray(pageData) || pageData.length === 0) {
+                    break;
+                }
+
+                all.push(...pageData);
+
+                if (pageData.length < API_PAGE_SIZE) {
+                    break;
+                }
+
+                page += 1;
+            }
+
+            return all;
+        };
+
+        const readRepoFromUrl = () => {
+            const params = new URLSearchParams(window.location.search);
+            const owner = params.get('owner') || DEFAULT_OWNER;
+            const repo = params.get('repo') || DEFAULT_REPO;
+            state.owner = owner;
+            state.repo = repo;
+            ownerInput.value = owner;
+            repoInput.value = repo;
+        };
+
+        const updateUrlWithRepo = () => {
+            const params = new URLSearchParams(window.location.search);
+            params.set('owner', state.owner);
+            params.set('repo', state.repo);
+            const newUrl = `${window.location.pathname}?${params.toString()}`;
+            window.history.replaceState({}, '', newUrl);
+        };
+
+        const createReleaseBody = (release) => {
+            const body = document.createElement('div');
+            body.className = 'release-body';
+            body.textContent = release.body || 'Sem notas de atualização.';
+            return body;
+        };
+
+        const copyToClipboard = async (text) => {
+            try {
+                await navigator.clipboard.writeText(text);
+                return true;
+            } catch (error) {
+                console.warn('navigator.clipboard indisponível, fallback execCommand.', error);
+                const input = document.createElement('input');
+                input.value = text;
+                document.body.appendChild(input);
+                input.select();
+                const copied = document.execCommand('copy');
+                input.remove();
+                return copied;
+            }
+        };
+
+        const renderSummary = (releases) => {
+            const assets = releases.reduce((acc, release) => acc + release.assets.length, 0);
+            const downloads = releases.reduce((acc, release) => acc + totalDownloads(release), 0);
+            const totalPages = Math.max(1, Math.ceil(releases.length / PAGE_SIZE));
+
+            summaryContainer.innerHTML = '';
+
+            const badges = [
+                `Repositório: ${state.owner}/${state.repo}`,
+                `Releases exibidas: ${releases.length}`,
+                `Arquivos: ${assets}`,
+                `Downloads totais: ${downloads}`,
+                `Página ${state.currentPage} de ${totalPages}`
+            ];
+
+            badges.forEach((label) => {
+                const badge = document.createElement('span');
+                badge.className = 'badge';
+                badge.textContent = label;
+                summaryContainer.appendChild(badge);
             });
+        };
+
+        const sortReleases = (releases, sortValue) => {
+            const sorted = [...releases];
+
+            if (sortValue === 'oldest') {
+                return sorted.sort((a, b) => new Date(a.published_at) - new Date(b.published_at));
+            }
+
+            if (sortValue === 'assets') {
+                return sorted.sort((a, b) => b.assets.length - a.assets.length);
+            }
+
+            if (sortValue === 'downloads') {
+                return sorted.sort((a, b) => totalDownloads(b) - totalDownloads(a));
+            }
+
+            return sorted.sort((a, b) => new Date(b.published_at) - new Date(a.published_at));
+        };
+
+        const getFilteredReleases = () => {
+            const query = searchInput.value.trim().toLowerCase();
+            const includePrerelease = showPrerelease.checked;
+
+            return state.allReleases.filter((release) => {
+                if (!includePrerelease && release.prerelease) {
+                    return false;
+                }
+
+                if (!query) {
+                    return true;
+                }
+
+                const haystack = [release.name, release.tag_name, release.body].join(' ').toLowerCase();
+                return haystack.includes(query);
+            });
+        };
+
+        const renderPagination = (totalItems) => {
+            const totalPages = Math.max(1, Math.ceil(totalItems / PAGE_SIZE));
+            if (state.currentPage > totalPages) {
+                state.currentPage = totalPages;
+            }
+
+            paginationContainer.innerHTML = '';
+
+            const prevBtn = document.createElement('button');
+            prevBtn.type = 'button';
+            prevBtn.textContent = '← Anterior';
+            prevBtn.disabled = state.currentPage <= 1;
+            prevBtn.addEventListener('click', () => {
+                state.currentPage -= 1;
+                renderReleases();
+            });
+
+            const pageInfo = document.createElement('span');
+            pageInfo.textContent = `Página ${state.currentPage} de ${totalPages}`;
+
+            const nextBtn = document.createElement('button');
+            nextBtn.type = 'button';
+            nextBtn.textContent = 'Próxima →';
+            nextBtn.disabled = state.currentPage >= totalPages;
+            nextBtn.addEventListener('click', () => {
+                state.currentPage += 1;
+                renderReleases();
+            });
+
+            paginationContainer.appendChild(prevBtn);
+            paginationContainer.appendChild(pageInfo);
+            paginationContainer.appendChild(nextBtn);
+        };
+
+        const renderReleases = () => {
+            releasesContainer.innerHTML = '';
+            const filtered = getFilteredReleases();
+            const sorted = sortReleases(filtered, sortSelect.value);
+            const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+
+            if (state.currentPage > totalPages) {
+                state.currentPage = totalPages;
+            }
+
+            const start = (state.currentPage - 1) * PAGE_SIZE;
+            const paginated = sorted.slice(start, start + PAGE_SIZE);
+
+            renderSummary(sorted);
+            renderPagination(sorted.length);
+
+            if (paginated.length === 0) {
+                releasesContainer.innerHTML = '<div class="empty">Nenhum resultado encontrado com os filtros atuais.</div>';
+                return;
+            }
+
+            paginated.forEach((release) => {
+                const card = document.createElement('article');
+                card.className = 'release-card';
+
+                const header = document.createElement('div');
+                header.className = 'release-header';
+
+                const title = document.createElement('h2');
+                title.className = 'release-title';
+                const titleLink = document.createElement('a');
+                titleLink.href = release.html_url;
+                titleLink.target = '_blank';
+                titleLink.rel = 'noopener noreferrer';
+                titleLink.textContent = release.name || release.tag_name;
+                title.appendChild(titleLink);
+
+                const tag = document.createElement('span');
+                tag.className = 'release-tag';
+                tag.textContent = `# ${release.tag_name}`;
+
+                header.appendChild(title);
+                header.appendChild(tag);
+
+                if (release.prerelease) {
+                    const pre = document.createElement('span');
+                    pre.className = 'release-tag prerelease';
+                    pre.textContent = 'Pré-release';
+                    header.appendChild(pre);
+                }
+
+                const date = document.createElement('div');
+                date.className = 'release-date';
+                date.textContent = `Publicado em: ${formatDate(release.published_at)} • ${release.assets.length} arquivo(s) • ${totalDownloads(release)} downloads`;
+                header.appendChild(date);
+
+                const body = createReleaseBody(release);
+                const assetsContainer = document.createElement('div');
+                assetsContainer.className = 'assets-list';
+
+                if (release.assets.length > 0) {
+                    release.assets.forEach((asset) => {
+                        const row = document.createElement('div');
+                        row.className = 'asset-row';
+
+                        const btn = document.createElement('a');
+                        btn.className = 'download-btn';
+                        btn.href = asset.browser_download_url;
+                        btn.target = '_blank';
+                        btn.rel = 'noopener noreferrer';
+                        btn.innerHTML = `
+                            <i class="fas fa-download"></i>
+                            <div class="file-info">
+                                <span class="file-name"></span>
+                                <span class="file-size"></span>
+                            </div>
+                        `;
+                        btn.querySelector('.file-name').textContent = asset.name;
+                        btn.querySelector('.file-size').textContent = `${formatBytes(asset.size)} • ${asset.download_count} downloads`;
+
+                        const copyBtn = document.createElement('button');
+                        copyBtn.type = 'button';
+                        copyBtn.className = 'copy-btn';
+                        copyBtn.textContent = 'Copiar link';
+                        copyBtn.addEventListener('click', async () => {
+                            const ok = await copyToClipboard(asset.browser_download_url);
+                            copyBtn.textContent = ok ? 'Copiado!' : 'Falhou';
+                            setTimeout(() => {
+                                copyBtn.textContent = 'Copiar link';
+                            }, 1200);
+                        });
+
+                        row.appendChild(btn);
+                        row.appendChild(copyBtn);
+                        assetsContainer.appendChild(row);
+                    });
+                } else {
+                    const noAsset = document.createElement('p');
+                    noAsset.style.fontSize = '0.9rem';
+                    noAsset.style.color = 'var(--text-muted)';
+                    noAsset.textContent = 'Nenhum arquivo anexado (apenas código fonte).';
+                    assetsContainer.appendChild(noAsset);
+                }
+
+                card.appendChild(header);
+                card.appendChild(body);
+                card.appendChild(assetsContainer);
+                releasesContainer.appendChild(card);
+            });
+        };
+
+        const loadReleases = async () => {
+            loader.style.display = 'block';
+            releasesContainer.innerHTML = '';
+
+            const cached = getCachedReleases();
+            if (cached) {
+                state.allReleases = cached;
+                loader.style.display = 'none';
+                renderReleases();
+                return;
+            }
+
+            const data = await fetchAllReleases();
+            state.allReleases = Array.isArray(data) ? data : [];
+            setCachedReleases(state.allReleases);
+            loader.style.display = 'none';
+            renderReleases();
+        };
+
+        const updateRepoFromInputs = () => {
+            const owner = ownerInput.value.trim();
+            const repo = repoInput.value.trim();
+
+            if (!owner || !repo) {
+                alert('Informe owner e repo válidos.');
+                return;
+            }
+
+            state.owner = owner;
+            state.repo = repo;
+            state.currentPage = 1;
+            updateUrlWithRepo();
+            init();
+        };
+
+        const attachControls = () => {
+            searchInput.addEventListener('input', () => {
+                state.currentPage = 1;
+                renderReleases();
+            });
+            sortSelect.addEventListener('change', () => {
+                state.currentPage = 1;
+                renderReleases();
+            });
+            showPrerelease.addEventListener('change', () => {
+                state.currentPage = 1;
+                renderReleases();
+            });
+            applyRepoBtn.addEventListener('click', updateRepoFromInputs);
+            themeToggle.addEventListener('click', toggleTheme);
+        };
+
+        const renderError = (error) => {
+            loader.style.display = 'none';
+            console.error('Erro:', error);
+            summaryContainer.innerHTML = '';
+            paginationContainer.innerHTML = '';
+            releasesContainer.innerHTML = `
+                <div class="error-msg">
+                    <h3><i class="fas fa-exclamation-triangle"></i> Ops!</h3>
+                    <p>Não foi possível carregar as releases de ${state.owner}/${state.repo}.</p>
+                    <p>Verifique se o repositório é público ou tente novamente mais tarde.</p>
+                    <small>Erro: ${error.message}</small>
+                </div>
+            `;
+        };
+
+        const init = async () => {
+            try {
+                await loadReleases();
+            } catch (error) {
+                renderError(error);
+            }
+        };
+
+        readRepoFromUrl();
+        initTheme();
+        attachControls();
+        init();
     </script>
 </body>
 </html>

--- a/readme.md
+++ b/readme.md
@@ -1,24 +1,45 @@
 # Auto Down
 
-Este é um simples projeto web que exibe as releases de um repositório GitHub diretamente em uma página HTML. Ele foi desenvolvido para facilitar o acesso aos assets das releases sem a necessidade de navegar diretamente pelo GitHub.
+Projeto web estático para listar releases de repositórios GitHub e facilitar o download de assets sem precisar navegar manualmente pela página de releases.
 
-## Funcionalidades
+## Funcionalidades atuais
 
-Busca automática das releases de um repositório GitHub.
-Exibição do nome das releases.
-Links diretos para download dos assets de cada release.
-
-## Como funciona
-
-O código JavaScript integrado à página HTML realiza uma requisição à API do GitHub para buscar as releases do repositório especificado. Em seguida, as informações das releases são exibidas na página, com links para download dos arquivos.
+- Busca de releases via API do GitHub com paginação automática (`per_page=100` + múltiplas páginas quando necessário).
+- Suporte a múltiplos repositórios configuráveis por URL:
+  - `?owner=SEU_OWNER&repo=SEU_REPO`
+- Barra de configuração para trocar `owner/repo` em tempo real.
+- Busca por texto (nome, tag e descrição).
+- Ordenação por:
+  - Mais recentes
+  - Mais antigas
+  - Mais arquivos
+  - Mais downloads
+- Opção para incluir/excluir pré-releases.
+- Paginação para listas grandes (6 releases por página na UI).
+- Resumo dinâmico com:
+  - Repositório atual
+  - Total de releases exibidas
+  - Total de arquivos
+  - Total de downloads
+  - Página atual
+- Cache local com `localStorage` (TTL de 5 minutos) para reduzir chamadas na API.
+- Botão “Copiar link” em cada asset.
+- Tema claro/escuro com alternância manual e persistência em `localStorage`.
 
 ## Como usar
 
-Para utilizar este código, basta alterar os valores das constantes `repoOwner` e `repoName` para o proprietário e o nome do repositório desejado.
+1. Abra o `index.html` no navegador.
+2. Opcionalmente, já abra com parâmetros de URL:
 
-const repoOwner = 'Seu Nome De Usuário';
-const repoName = 'Nome Do Seu Repositório';
+```text
+index.html?owner=phoenixsrd&repo=autodowm
+```
 
-## Atenção 
+3. Use a barra superior para:
+   - Trocar `owner/repo`
+   - Buscar e ordenar releases
+   - Incluir pré-releases
+   - Alternar entre tema claro/escuro
+4. Clique em **Carregar** para atualizar o repositório alvo.
 
-Para a API buscar seus arquivos, deixe seu repositório público.
+> O repositório precisa ser público para a API retornar as releases sem autenticação.


### PR DESCRIPTION
### Motivation

- Modernize the single-file UI to make browsing GitHub releases faster and more user-friendly. 
- Reduce repeated API calls and support large release sets by adding pagination and caching. 
- Provide convenience actions like copying asset links and switching themes for better UX.

### Description

- Reworked `index.html` layout and styles to include a toolbar, repository selector (`owner`/`repo` inputs), summary badges, pagination, responsive design and visual improvements; added a theme toggle with persisted choice in `localStorage`.
- Replaced the single `fetch` call with `fetchAllReleases` that pages through the GitHub API (`per_page=100`) and aggregates results, and added a local cache with a 5-minute TTL stored under `autodowm-releases:owner/repo`.
- Implemented client-side filtering, search (name/tag/body), sorting (`newest`, `oldest`, `assets`, `downloads`), prerelease toggle, and UI pagination at `PAGE_SIZE = 6` with summary stats and guards for empty results.
- Added per-asset actions including a `Copiar link` button using `navigator.clipboard` fallback, improved error handling UI, URL query param handling (`?owner=&repo=`), and updated `readme.md` to document the new features and usage.

### Testing

- No automated tests are configured for this repository; changes were implemented without new CI/unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e31d1ce20c832291fd70dd8a3096e5)